### PR TITLE
add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false
+indent_style = tab


### PR DESCRIPTION
.editorconfig ファイルがなかったので、作りました。
設定内容は、既存のファイルを参照して決めてあります。


インデントがハードタブなので、インデントサイズは明記していません。

> indent_size: a whole number defining the number of columns used for each indentation level and the width of soft tabs (when supported). When set to tab, the value of tab_width (if specified) will be used.
> tab_width: a whole number defining the number of columns used to represent a tab character. This defaults to the value of indent_size and doesn't usually need to be specified.

editorconfig については、 http://editorconfig.org/ を御覧ください。
editorconfig の必要性については、 https://qiita.com/naru0504/items/82f09881abaf3f4dc171 あたりが参考になると思います。
