### PR TITLE
fix parameter object and method

### DIFF
--- a/tutorial/v3/audio.html
+++ b/tutorial/v3/audio.html
@@ -162,7 +162,10 @@ Ogg Vorbis 形式 (.ogg) と AAC 形式 (.aac) の二種類のファイルを用
 <pre><code class="language-javascript">scene.asset.getAudioById(&quot;se1&quot;).play();</code></pre>
 <p>シーンで効果音を利用するには、他のアセットと同じようにシーンオブジェクトのパラメータオブジェクトにアセットの ID を列挙します。以下は画面のタップまたはクリックで効果音を再生する例です。</p>
 <pre><code class="language-javascript">function main() {
-  var scene = new g.Scene({ assetIds: [&quot;se1&quot;] });
+  var scene = new g.Scene({
+		game: g.game,
+		assetIds: [&quot;se1&quot;]
+	});
   scene.onLoad.add(function() {
     scene.onPointDownCapture.add(function() {
       scene.asset.getAudioById(&quot;se1&quot;).play();
@@ -194,9 +197,12 @@ BGM をループ再生させるには、<code>game.json</code> を編集して�
 BGM は自動的にループ再生されるので、<code>play()</code> メソッドはシーンロード時に一度だけ呼び出します。</p>
 <p>以下のプログラムは上で出てきた効果音再生プログラムに BGM を追加したものです。</p>
 <pre><code class="language-javascript">function main() {
-  var scene = new g.Scene({ assetIds: [&quot;bgm&quot;, &quot;se1&quot;] });
+  var scene = new g.Scene({
+		game: g.game,
+		assetIds: [&quot;bgm&quot;, &quot;se1&quot;]
+	});
   scene.onLoad.add(function() {
-    scene.asset.getAudioAssetById(&quot;bgm&quot;).play();
+    scene.asset.getAudioById(&quot;bgm&quot;).play();
     scene.onPointDownCapture.add(function() {
       scene.asset.getAudioById(&quot;se1&quot;).play();
     });


### PR DESCRIPTION
・add forgotten game property to parameter object of Scene.

・getAudioAssetById doesn't seem to exist, so change it to getAudioById.
